### PR TITLE
add links from notes to their detail page

### DIFF
--- a/lmn/templates/lmn/notes/note_list.html
+++ b/lmn/templates/lmn/notes/note_list.html
@@ -12,7 +12,9 @@
 {% for note in notes %}
 
   <div id="note_{{ note.pk }}">
-    <h3 class="note-title">{{ note.title }}</h3>
+    <h3 class="note_title">
+      <a href="{% url 'note_detail' note_pk=note.pk %}">{{ note.title }}</a>
+    </h3>
 
     <p class="show-info">
       <a href="{% url 'notes_for_show' show_pk=note.show.pk %}">{{ note.show.artist.name }} at {{ note.show.venue.name }} on {{ note.show.show_date }}</a>
@@ -23,6 +25,7 @@
     </p>
 
     <p class='note-text'>{{ note.text|truncatechars:100 }}</p>
+
   </div>  
 
   <hr>


### PR DESCRIPTION
The notes page now has links between notes and their detail pages. @Nelwell @abdiawali @PickleEric 