### PR TITLE
Edit and Delete Notes

### DIFF
--- a/lmn/static/js/confirm_delete.js
+++ b/lmn/static/js/confirm_delete.js
@@ -1,0 +1,28 @@
+// Find all the delete buttons, add a click event listener to all buttons
+// On click event, show a confirm dialog
+// Browsers will handle these events before the click that submits the form
+// to provide the opportunity to intercept the form submit with JavaScript.
+// If the click event handler prevents the event propagating, the form submit
+// never happens.  If the click event doesn't prevent the event propagating,
+// the form will be submitted as usual.
+
+var deleteButtons = document.querySelectorAll('.delete');
+
+deleteButtons.forEach(function(button){
+
+  button.addEventListener('click', function(ev){
+
+    // Show a confirm dialog
+    var okToDelete = confirm("Delete note - are you sure?");
+
+    // If user presses no, prevent the form submit
+    if (!okToDelete) {
+      ev.preventDefault();  // Prevent the click event propagating
+    }
+
+    // Otherwise, the web page will continue processing the event, 
+    // and send the delete request to the server.
+
+
+  })
+});

--- a/lmn/templates/lmn/notes/edit_note.html
+++ b/lmn/templates/lmn/notes/edit_note.html
@@ -1,0 +1,15 @@
+{% extends 'lmn/base.html' %}
+{% block content %}
+
+<h2>Edit Note</h2>
+
+<form method="POST" action="{% url 'edit_note' note_pk=note.pk %}">
+  
+  <div>
+    {% csrf_token %}
+    {{ review_form.as_p }}
+  </div>
+  <input type='submit' value='Update Note'>
+</form>
+
+{% endblock %}

--- a/lmn/templates/lmn/notes/note_detail.html
+++ b/lmn/templates/lmn/notes/note_detail.html
@@ -9,10 +9,13 @@
 <p id="note-title"><b>{{ note.title}}</b></p>
 <p id="note-text">{{ note.text }}</b>
 
-<p>
-    <a class='edit' href="{% url 'edit_note' note_pk=note.pk %}">Edit</a>
-</p>
+{% if note.user.pk == user.pk %}
 
+    <p>
+        <a class='edit' href="{% url 'edit_note' note_pk=note.pk %}">Edit</a>
+    </p>
+
+{% endif %}
 
     
 

--- a/lmn/templates/lmn/notes/note_detail.html
+++ b/lmn/templates/lmn/notes/note_detail.html
@@ -1,4 +1,5 @@
 {% extends 'lmn/base.html' %}
+{% load static %}
 {% block content %}
 
 
@@ -15,8 +16,14 @@
         <a class='edit' href="{% url 'edit_note' note_pk=note.pk %}">Edit</a>
     </p>
 
+    <form action="{% url 'delete_note' note.pk %}" method="POST">
+        {% csrf_token %}
+        <button type=submit class="delete">DELETE</button>
+    </form>
+
+    <script src="{% static 'js/confirm_delete.js' %}"></script>
+
 {% endif %}
-
     
-
 {% endblock %}
+

--- a/lmn/templates/lmn/notes/note_detail.html
+++ b/lmn/templates/lmn/notes/note_detail.html
@@ -9,4 +9,11 @@
 <p id="note-title"><b>{{ note.title}}</b></p>
 <p id="note-text">{{ note.text }}</b>
 
+<p>
+    <a class='edit' href="{% url 'edit_note' note_pk=note.pk %}">Edit</a>
+</p>
+
+
+    
+
 {% endblock %}

--- a/lmn/templates/lmn/notes/note_list.html
+++ b/lmn/templates/lmn/notes/note_list.html
@@ -23,6 +23,7 @@
     </p>
 
     <p class='note-text'>{{ note.text|truncatechars:100 }}</p>
+
   </div>  
 
   <hr>

--- a/lmn/urls.py
+++ b/lmn/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path('notes/detail/<int:note_pk>/', views_notes.note_detail, name='note_detail'),
     path('notes/for_show/<int:show_pk>/', views_notes.notes_for_show, name='notes_for_show'),
     path('notes/add/<int:show_pk>/', views_notes.new_note, name='new_note'),
+    path('notes/edit/<int:note_pk>/', views_notes.edit_note, name='edit_note'),
 
     # Artist related
     path('artists/list/', views_artists.artist_list, name='artist_list'),

--- a/lmn/urls.py
+++ b/lmn/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path('notes/for_show/<int:show_pk>/', views_notes.notes_for_show, name='notes_for_show'),
     path('notes/add/<int:show_pk>/', views_notes.new_note, name='new_note'),
     path('notes/edit/<int:note_pk>/', views_notes.edit_note, name='edit_note'),
+    path('notes/delete/<int:note_pk>/', views_notes.delete_note, name='delete_note'),
 
     # Artist related
     path('artists/list/', views_artists.artist_list, name='artist_list'),

--- a/lmn/views/views_notes.py
+++ b/lmn/views/views_notes.py
@@ -44,3 +44,21 @@ def notes_for_show(request, show_pk):
 def note_detail(request, note_pk):
     note = get_object_or_404(Note, pk=note_pk)
     return render(request, 'lmn/notes/note_detail.html' , { 'note': note })
+
+    
+def edit_note(request, note_pk):
+    note = get_object_or_404(Note, pk=note_pk)
+
+    if request.method == 'POST':
+        form = NewNoteForm(request.POST, request.FILES, instance=note)
+
+        if form.is_valid(): # if all fields are filled out correctly, save the contents of the form to database
+            form.save()
+
+        return redirect('note_detail', note_pk=note_pk)
+
+    else: # this displays the place details if the request method is 'GET' instead of 'POST'
+        review_form = NewNoteForm(instance=note) # reuse NewNoteForm for editing notes.
+        return render(request, 'lmn/notes/edit_note.html', {'note': note, 'review_form': review_form})
+        
+

--- a/lmn/views/views_notes.py
+++ b/lmn/views/views_notes.py
@@ -6,6 +6,7 @@ from ..forms import VenueSearchForm, NewNoteForm, ArtistSearchForm, UserRegistra
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login, logout
+from django.http import HttpResponseForbidden
 
 
 
@@ -49,6 +50,9 @@ def note_detail(request, note_pk):
 @login_required    
 def edit_note(request, note_pk):
     note = get_object_or_404(Note, pk=note_pk)
+
+    if note.user != request.user: # return an error if a user attempts to edit a note that doesn't belong to them
+        return HttpResponseForbidden()
 
     if request.method == 'POST':
         form = NewNoteForm(request.POST, request.FILES, instance=note)

--- a/lmn/views/views_notes.py
+++ b/lmn/views/views_notes.py
@@ -67,3 +67,12 @@ def edit_note(request, note_pk):
         return render(request, 'lmn/notes/edit_note.html', {'note': note, 'review_form': review_form})
         
 
+@login_required
+def delete_note(request, note_pk):
+    note = get_object_or_404(Note, pk=note_pk)
+
+    if note.user == request.user:
+        note.delete()
+        return redirect('user_profile', user_pk=note.user.pk) # redirects to the user's profile after deleting
+    else:
+        return HttpResponseForbidden()

--- a/lmn/views/views_notes.py
+++ b/lmn/views/views_notes.py
@@ -45,7 +45,8 @@ def note_detail(request, note_pk):
     note = get_object_or_404(Note, pk=note_pk)
     return render(request, 'lmn/notes/note_detail.html' , { 'note': note })
 
-    
+
+@login_required    
 def edit_note(request, note_pk):
     note = get_object_or_404(Note, pk=note_pk)
 


### PR DESCRIPTION
A user can now edit and delete notes that belong to them. Buttons to edit and delete only display on notes that belong to the users. To test this feature, navigate to the note_detail page for a note. If my other pull requests haven't been merged yet, you may need to navigate manually in the browser:   http://127.0.0.1:8000/notes/detail/[primary key of note]

@John151 @Nelwell @abdiawali @PickleEric 